### PR TITLE
verify cluster status after installation and fail the ansible job if cluster fails

### DIFF
--- a/roles/centos7/dashboards/tasks/etchosts.yml
+++ b/roles/centos7/dashboards/tasks/etchosts.yml
@@ -3,7 +3,7 @@
   blockinfile:
     dest: /etc/hosts
     block: |-
-      {% for item in groups['os-cluster'] %}
+      {% for item in groups['dashboards'] %}
       {{ hostvars[item]['ip'] }} {{ item }}.{{ domain_name }} {{ item }}
       {% endfor %}
     state: present

--- a/roles/centos7/opensearch/tasks/main.yml
+++ b/roles/centos7/opensearch/tasks/main.yml
@@ -40,3 +40,4 @@
 - name: Show the opensearch status
   debug:
     msg: "{{ os_status.stdout }}"
+  failed_when: "'number_of_nodes' not in os_status.stdout"


### PR DESCRIPTION
Signed-off-by: saravanan palanisamy <saravanan30erd@gmail.com>

### Description

Verify the opensearch cluster status after installation, and pass the ansible job only if the cluster status is fine otherwise fail the job. In some scenarios, ansible job will be completed without any issues but opensearch cluster might have issues. so we are failing the ansible job if the cluster have any issues.
 
### Issues Resolved
issue: #6 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
