### PR TITLE
[Fix issue-30] Add opensearch/dashboards specific user variable to define user and group on creation

### DIFF
--- a/inventories/opensearch/group_vars/all/all.yml
+++ b/inventories/opensearch/group_vars/all/all.yml
@@ -16,8 +16,6 @@ os_dashboards_version: "1.2.0"
 # Example es1.example.com, es2.example.com
 domain_name: example.com
 
-os_user: opensearch
-
 # Java memory heap values(GB) for opensearch
 # You can change it based on server specs
 xms_value: 2
@@ -25,3 +23,8 @@ xmx_value: 2
 
 # Cluster type whether its single node or multi-node
 cluster_type: multi-node
+
+# opensearch user info
+os_user: opensearch
+
+os_dashboards_user: opensearch-dashboards

--- a/roles/linux/dashboards/tasks/dashboards.yml
+++ b/roles/linux/dashboards/tasks/dashboards.yml
@@ -8,7 +8,7 @@
 
 - name: Dashboards Install | Create opensearch user
   user:
-    name: "{{ os_user }}"
+    name: "{{ os_dashboards_user }}"
     state: present
     shell: /bin/bash
   when: download.changed
@@ -17,8 +17,8 @@
   file:
     path: "{{ os_dashboards_home }}"
     state: directory
-    owner: "{{ os_user }}"
-    group: "{{ os_user }}"
+    owner: "{{ os_dashboards_user }}"
+    group: "{{ os_dashboards_user }}"
   when: download.changed
 
 - name: Dashboards Install | Extract the tar file
@@ -29,8 +29,8 @@
   template:
     src: opensearch_dashboards.yml
     dest: "{{os_conf_dir}}/opensearch_dashboards.yml"
-    owner: "{{ os_user }}"
-    group: "{{ os_user }}"
+    owner: "{{ os_dashboards_user }}"
+    group: "{{ os_dashboards_user }}"
     mode: 0644
     backup: yes
 

--- a/roles/linux/dashboards/tasks/main.yml
+++ b/roles/linux/dashboards/tasks/main.yml
@@ -25,7 +25,7 @@
     enabled: yes
 
 - name: Get all the installed dashboards plugins
-  command: "sudo -u {{ os_user }} {{ os_plugin_bin_path }} list"
+  command: "sudo -u {{ os_dashboards_user }} {{ os_plugin_bin_path }} list"
   register: list_plugins
 
 - name: Show all the installed dashboards plugins

--- a/roles/linux/dashboards/templates/dashboards.service
+++ b/roles/linux/dashboards/templates/dashboards.service
@@ -9,8 +9,8 @@ PrivateTmp=true
 
 WorkingDirectory={{ os_dashboards_home }}
 
-User=opensearch
-Group=opensearch
+User={{ os_dashboards_user }}
+Group={{ os_dashboards_user }}
 
 ExecStart={{ os_dashboards_home }}/bin/opensearch-dashboards -q
 

--- a/roles/linux/opensearch/templates/opensearch.service
+++ b/roles/linux/opensearch/templates/opensearch.service
@@ -9,8 +9,8 @@ PrivateTmp=true
 
 WorkingDirectory={{ os_home }}
 
-User=opensearch
-Group=opensearch
+User={{ os_user }}
+Group={{ os_user }}
 
 ExecStart={{ os_home }}/bin/opensearch -p {{ os_home }}/opensearch.pid -q
 


### PR DESCRIPTION
Fix Issue: #30 

Only `user` variable is enough, adding `group` variable will create issues.
Linux creates both user and group during an user creation, and we can use the same user and group for running an application. If we provide another separate variable for `group` then someone may use two different values for `user` and `group` that requires another group creation and further group management which is unnecessary and tedious process.

