### PR TITLE
Bump opensearch version to 1.2.4 in ansible playbook

### DIFF
--- a/inventories/opensearch/group_vars/all/all.yml
+++ b/inventories/opensearch/group_vars/all/all.yml
@@ -6,7 +6,7 @@ os_cluster_name: development-cluster
 os_download_url: https://artifacts.opensearch.org/releases/bundle/opensearch
 
 # opensearch version
-os_version: "1.2.3"
+os_version: "1.2.4"
 
 # opensearch dashboards version
 os_dashboards_version: "1.2.0"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Bump opensearch version to 1.2.4 in ansible playbook
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
