### PR TITLE
issue #39 workaround for opensearch config override

### DIFF
--- a/inventories/opensearch/group_vars/all/all.yml
+++ b/inventories/opensearch/group_vars/all/all.yml
@@ -21,7 +21,7 @@ domain_name: example.com
 xms_value: 2
 xmx_value: 2
 
-# Cluster type whether its single node or multi-node
+# Cluster type whether its single-node or multi-node
 cluster_type: multi-node
 
 # opensearch user info

--- a/roles/linux/opensearch/tasks/opensearch.yml
+++ b/roles/linux/opensearch/tasks/opensearch.yml
@@ -26,13 +26,16 @@
   when: download.changed
 
 - name: OpenSearch Install | Copy Configuration File
-  template:
-    src: "opensearch-{{ cluster_type }}.yml"
-    dest: "{{os_conf_dir}}/opensearch.yml"
+  blockinfile:
+    block: "{{ lookup('template', 'templates/opensearch-{{ cluster_type }}.yml') }}"
+    dest: "{{ os_conf_dir }}/opensearch.yml"
+    backup: yes
+    state: present
+    create: yes
+    marker: "## {mark} opensearch main configuration ##"
     owner: "{{ os_user }}"
     group: "{{ os_user }}"
     mode: 0600
-    backup: yes
 
 - name: OpenSearch Install | Copy jvm.options File for Instance
   template:


### PR DESCRIPTION
Issue #39 

Instead of copying whole file(which doing overwrite the complete file), validating the content and copying only the content.

@peterzhuamazon  Tested only with `single-node`. Cluster is fine even after 2 times re-run.
