### PR TITLE
Become: false for operation /tmp/opensearch-nodecerts

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -9,6 +9,7 @@
     state: directory
   run_once: true
   register: configuration
+  become: false
 
 - name: Security Plugin configuration | Download certificates generation tool
   local_action:
@@ -17,11 +18,13 @@
     dest: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
   run_once: true
   when: configuration.changed
+  become: false
 
 - name: Security Plugin configuration | Extract the certificates generation tool
   local_action: command chdir=/tmp/opensearch-nodecerts tar -xvf search-guard-tlstool.tar.gz
   run_once: true
   when: configuration.changed
+  become: false
 
 - name: Security Plugin configuration | Make the executable file
   local_action:


### PR DESCRIPTION
Signed-off-by: Anton Patsev <patsev.anton@gmail.com>

### Description
Become: false for operation /tmp/opensearch-nodecerts
 
### Issues Resolved
Fix https://github.com/opensearch-project/ansible-playbook/issues/45
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
