### PR TITLE
Troubleshooting error launching dashboards after installation

### DIFF
--- a/roles/linux/dashboards/tasks/dashboards.yml
+++ b/roles/linux/dashboards/tasks/dashboards.yml
@@ -33,6 +33,20 @@
     group: "{{ os_dashboards_user }}"
     mode: 0644
     backup: yes
+    
+- name: Dashboards Install | Set the file ownerships
+  file:
+    dest: "{{ os_dashboards_home }}"
+    owner: "{{ os_dashboards_user }}"
+    group: "{{ os_dashboards_user }}"
+    recurse: yes
+
+- name: Dashboards Install | Set the folder permission
+  file:
+    dest: "{{ os_conf_dir }}"
+    owner: "{{ os_dashboards_user }}"
+    group: "{{ os_dashboards_user }}"
+    mode: 0700
 
 - name: Dashboards Install | create systemd service
   template:


### PR DESCRIPTION
Set ownerships for dashboards home directory and permissions for conf dir by analogy with opensearch role (security.yml)

### Description
After apply role "dashboards", service dashboards does not starting with error message "opensearch-dashboards[219171]:  FATAL  Error: Unable to write OpenSearch Dashboards UUID file, please check the uuid.server configuration value in opensearch_dashboards.yml and ensure OpenSearch Dashboards has sufficient permissions to read / write to this file. Error was: EACCES"

### Issues Resolved
https://github.com/opensearch-project/ansible-playbook/pull/59

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
