### PR TITLE
[Backport 1.x] Add saravanan30erd as the default reviewer of ansible repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/engineering-effectiveness
+*   @opensearch-project/engineering-effectiveness @saravanan30erd


### PR DESCRIPTION
### Description
[Backport 1.x] Add saravanan30erd as the default reviewer of ansible repo

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
