### PR TITLE
[1.x] Fix nonexistent "os_sec_plugin_conf_path" directory error.

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -146,6 +146,15 @@
     marker: "## {mark} opensearch Security Node & Admin certificates configuration ##"
   when: configuration.changed or iac_enable
 
+- name: Security Plugin configuration | Create security plugin configuration folder
+  file:
+    dest: "{{ os_sec_plugin_conf_path }}"
+    owner: "{{ os_user }}"
+    group: "{{ os_user }}"
+    mode: 0700
+    state: directory
+  when: configuration.changed or iac_enable
+
 - name: Security Plugin configuration | Copy the security configuration file 3 to cluster
   template:
     src: security_plugin_conf.yml


### PR DESCRIPTION
Signed-off-by: Rodolfo Camara Villordo <rodolfovillordo@gmail.com>

### Description
Fix missing plugin configuration directory

### Issues Resolved
https://github.com/opensearch-project/ansible-playbook/issues/80

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
