### PR TITLE
become: false on "Check that the files/internal_users.yml exists"

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -229,6 +229,7 @@
   register: custom_users_result
   delegate_to: localhost
   run_once: true
+  become: false
 
 - name: Security Plugin configuration | Check for a custom configuration for internal users and hash passwords for them
   block:


### PR DESCRIPTION
Signed-off-by: Rodolfo Camara Villordo <rodolfovillordo@gmail.com>

### Description
removes unnecessary elevation of privileges

### Issues Resolved
resolve #82 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
