### PR TITLE
Fix securityadmin.sh when copy_custom_security_configs is False

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -276,7 +276,21 @@
   environment:
     JAVA_HOME: "{{ os_home }}/jdk"
   run_once: true
-  when: configuration.changed or copy_custom_security_configs
+  when: configuration.changed and copy_custom_security_configs
+
+- name: Security Plugin configuration | Initialize the opensearch security index in opensearch
+  shell: >
+    bash {{ os_sec_plugin_tools_path }}/securityadmin.sh
+    -cacert {{ os_conf_dir }}/root-ca.pem
+    -cert {{ os_conf_dir }}/admin.pem
+    -key {{ os_conf_dir }}/admin.key
+    -f {{ os_sec_plugin_conf_path }}/internal_users.yml
+    -nhnv -icl
+    -h {{ hostvars[inventory_hostname]['ip'] }}
+  environment:
+    JAVA_HOME: "{{ os_home }}/jdk"
+  run_once: true
+  when: configuration.changed and not copy_custom_security_configs
 
 - name: Security Plugin configuration | Cleanup local temporary directory
   local_action:

--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -264,7 +264,7 @@
 
   when: custom_users_result.stat.exists
 
-- name: Security Plugin configuration | Initialize the opensearch security index in opensearch
+- name: Security Plugin configuration | Initialize the opensearch security index in opensearch with custom configs
   shell: >
     bash {{ os_sec_plugin_tools_path }}/securityadmin.sh
     -cacert {{ os_conf_dir }}/root-ca.pem
@@ -278,7 +278,7 @@
   run_once: true
   when: configuration.changed and copy_custom_security_configs
 
-- name: Security Plugin configuration | Initialize the opensearch security index in opensearch
+- name: Security Plugin configuration | Initialize the opensearch security index in opensearch with default configs
   shell: >
     bash {{ os_sec_plugin_tools_path }}/securityadmin.sh
     -cacert {{ os_conf_dir }}/root-ca.pem


### PR DESCRIPTION
Signed-off-by: Rodolfo Camara Villordo <rodolfovillordo@gmail.com>

### Description
Chenge condition to execute the securityadmin.sh script with the parameter `-cd` only when copy_custom_security_configs is true. Also add a task to execute securityadmin.sh with parameter `-f` when copy_custom_security_configs is set to false.

### Issues Resolved
fix #83 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
