### PR TITLE
Remove unecessary logstash user from default deployment

### DIFF
--- a/files/internal_users.yml
+++ b/files/internal_users.yml
@@ -19,8 +19,3 @@ kibanaserver:
   hash: "{{ kibanaserver_password }}"
   reserved: true
   description: "kibanaserver user"
-
-logstash:
-  hash: "{{ logstash_password }}"
-  reserved: true
-  description: "logstash user"


### PR DESCRIPTION
Signed-off-by: Rodolfo Camara Villordo <rodolfovillordo@gmail.com>

### Description
PR #63 left an unnecessary user for the default OpenSearch deployment. This PR is to remove the user from the internal_users.yml file.

### Issues Resolved
Fix #86 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
