### PR TITLE
Fix nonexistent os_sec_plugin_conf_path directory error

### DIFF
--- a/roles/linux/opensearch/defaults/main.yml
+++ b/roles/linux/opensearch/defaults/main.yml
@@ -15,7 +15,7 @@ populate_inventory_to_hosts_file: true
 os_home: /usr/share/opensearch
 os_conf_dir: /usr/share/opensearch/config
 os_plugin_bin_path: /usr/share/opensearch/bin/opensearch-plugin
-os_sec_plugin_conf_path: /usr/share/opensearch/plugins/opensearch-security/securityconfig
+os_sec_plugin_conf_path: /usr/share/opensearch/config/opensearch-security
 os_sec_plugin_tools_path: /usr/share/opensearch/plugins/opensearch-security/tools
 os_api_port: 9200
 

--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -146,6 +146,15 @@
     marker: "## {mark} opensearch Security Node & Admin certificates configuration ##"
   when: configuration.changed or iac_enable
 
+- name: Security Plugin configuration | Create security plugin configuration folder
+  file:
+    dest: "{{ os_sec_plugin_conf_path }}"
+    owner: "{{ os_user }}"
+    group: "{{ os_user }}"
+    mode: 0700
+    state: directory
+  when: configuration.changed or iac_enable
+
 - name: Security Plugin configuration | Copy the security configuration file 3 to cluster
   template:
     src: security_plugin_conf.yml


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix nonexistent os_sec_plugin_conf_path directory error.

### Issues Resolved
#80

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
