### PR TITLE
[Backport 1.x] Fix securityadmin.sh when copy_custom_security_configs is False

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -273,7 +273,7 @@
 
   when: custom_users_result.stat.exists
 
-- name: Security Plugin configuration | Initialize the opensearch security index in opensearch
+- name: Security Plugin configuration | Initialize the opensearch security index in opensearch with custom configs
   shell: >
     bash {{ os_sec_plugin_tools_path }}/securityadmin.sh
     -cacert {{ os_conf_dir }}/root-ca.pem
@@ -285,7 +285,21 @@
   environment:
     JAVA_HOME: "{{ os_home }}/jdk"
   run_once: true
-  when: configuration.changed or copy_custom_security_configs
+  when: configuration.changed and copy_custom_security_configs
+
+- name: Security Plugin configuration | Initialize the opensearch security index in opensearch with default configs
+  shell: >
+    bash {{ os_sec_plugin_tools_path }}/securityadmin.sh
+    -cacert {{ os_conf_dir }}/root-ca.pem
+    -cert {{ os_conf_dir }}/admin.pem
+    -key {{ os_conf_dir }}/admin.key
+    -f {{ os_sec_plugin_conf_path }}/internal_users.yml
+    -nhnv -icl
+    -h {{ hostvars[inventory_hostname]['ip'] }}
+  environment:
+    JAVA_HOME: "{{ os_home }}/jdk"
+  run_once: true
+  when: configuration.changed and not copy_custom_security_configs
 
 - name: Security Plugin configuration | Cleanup local temporary directory
   local_action:


### PR DESCRIPTION
### Description
[Backport 1.x] Fix securityadmin.sh when copy_custom_security_configs is False

### Issues Resolved
#83

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
