### PR TITLE
Additional condition for ignoring of absent selinux module

### DIFF
--- a/roles/linux/dashboards/tasks/main.yml
+++ b/roles/linux/dashboards/tasks/main.yml
@@ -8,6 +8,8 @@
   selinux:
     state: disabled
   when: (ansible_distribution != "Ubuntu") and (ansible_distribution != "Amazon")
+  register: result
+  failed_when: result.msg | default('ok', True) is not search('(^ok$|libselinux-python|(SELinux state changed))')
 
 - name: Populate the nodes to /etc/hosts
   import_tasks: etchosts.yml

--- a/roles/linux/opensearch/tasks/main.yml
+++ b/roles/linux/opensearch/tasks/main.yml
@@ -8,6 +8,8 @@
   selinux:
     state: disabled
   when: (ansible_distribution != "Ubuntu") and (ansible_distribution != "Amazon")
+  register: result
+  failed_when: result.msg | default('ok', True) is not search('(^ok$|libselinux-python|(SELinux state changed))')
 
 - name: Populate the nodes to /etc/hosts
   import_tasks: etchosts.yml


### PR DESCRIPTION
### Description
When task "Disable the selinux" runs on OS without installed SELinux, for Example Debian, it is failed with error: "An exception occurred during task execution. The error was: ModuleNotFoundError: No module named 'selinux'". 
Additional condition in "failed_when" allow to ignore error of missing module.
The problem was discussed in [Selinux module fails if selinux is not installed](https://github.com/ansible/ansible/issues/62467)

### Issues Resolved
[Issue 111](https://github.com/opensearch-project/ansible-playbook/issues/111)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
