### PR TITLE
bump opensearch and opensearch-dashboards version to 1.3.9

### DIFF
--- a/inventories/opensearch/group_vars/all/all.yml
+++ b/inventories/opensearch/group_vars/all/all.yml
@@ -7,11 +7,11 @@ os_download_url: https://artifacts.opensearch.org/releases/bundle/opensearch
 
 # opensearch version
 # 1.x Latest Version
-os_version: "1.3.8"
+os_version: "1.3.9"
 
 # opensearch dashboards version
 # 1.x Latest Version
-os_dashboards_version: "1.3.8"
+os_dashboards_version: "1.3.9"
 
 # Configure hostnames for opensearch nodes
 # It is required to configure SSL


### PR DESCRIPTION
### Description
bump opensearch and opensearch-dashboards version to 1.3.9

### Issues Resolved
post task of release 1.3.9 at https://github.com/opensearch-project/opensearch-build/issues/3195

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
