### PR TITLE
wait for port to be open instead of hard-coded 10 seconds

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -191,7 +191,7 @@
     enabled: yes
 
 - name: Wait for opensearch to startup
-  wait_for: host={{ hostvars[inventory_hostname]['ip'] }} port={{os_api_port}} delay=5 connect_timeout=1
+  ansible.builtin.wait_for: host={{ hostvars[inventory_hostname]['ip'] }} port={{os_api_port}} delay=5 connect_timeout=1
 
 - name: Security Plugin configuration | Copy the opensearch security internal users template
   template:

--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -191,7 +191,9 @@
     enabled: yes
 
 - name: Wait for opensearch to startup
-  ansible.builtin.wait_for: host={{ hostvars[inventory_hostname]['ip'] }} port={{os_api_port}} delay=5 connect_timeout=1
+  ansible.builtin.wait_for: host={{ hostvars[inventory_hostname]['ip'] }} port={{os_api_port}} delay=5 connect_timeout=1 timeout=120
+
+
 
 - name: Security Plugin configuration | Copy the opensearch security internal users template
   template:

--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -190,9 +190,8 @@
     state: restarted
     enabled: yes
 
-- name: Pause for 10 seconds to provide sometime for OpenSearch start
-  pause:
-    seconds: 10
+- name: Wait for opensearch to startup
+  wait_for: host={{ hostvars[inventory_hostname]['ip'] }} port={{os_api_port}} delay=5 connect_timeout=1
 
 - name: Security Plugin configuration | Copy the opensearch security internal users template
   template:


### PR DESCRIPTION
### Description

instead of waiting hard-coded 10 seconds, better wait for the API port of opensearch to become available.

This is done in the same way in `roles/linux/opensearch/tasks/main.yml`, from where the replacing code was taken.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
