### PR TITLE
Add github-merit-badger.yml

### DIFF
--- a/.github/workflows/github-merit-badger.yml
+++ b/.github/workflows/github-merit-badger.yml
@@ -1,0 +1,21 @@
+---
+name: github-merit-badger
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  call-action:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: aws-github-ops/github-merit-badger@v0.0.98
+        id: merit-badger
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          badges: '[first-time-contributor,repeat-contributor,valued-contributor,seasoned-contributor,all-star-contributor,distinguished-contributor]'
+          thresholds: '[0,3,6,13,25,50]'
+          badge-type: 'achievement'
+          ignore-usernames: '[opensearch-ci-bot]'


### PR DESCRIPTION
### Description
Adding the POC of [github-merit-badger](https://github.com/aws-github-ops/github-merit-badger)
The labels as part of badges are auto created.
Sample tested PR: https://github.com/prudhvigodithi/opensearch-build/pull/51

This github-merit-badger would give better insights to repo maintainers and would enhance the open source community experience.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
