### PR TITLE
chore: wait for OS port instead of time

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -190,9 +190,11 @@
     state: restarted
     enabled: yes
 
-- name: Pause for 10 seconds to provide sometime for OpenSearch start
-  pause:
-    seconds: 10
+- name: Wait until OpenSearch ist listening on port 9200
+  ansible.builtin.wait_for:
+    port: "{{ os_api_port }}"
+    delay: 10
+    timeout: 120
 
 - name: Security Plugin configuration | Copy the opensearch security internal users template
   template:


### PR DESCRIPTION
### Description
Instead of waiting a fixed amount of time, wait until OpenSearch is listening on the port the securityadmin script uses.

### Issues Resolved
Fixes error `ERR: Seems there is no OpenSearch running on localhost:9200 - Will exit` when OpenSearch is not fast enough on startup and securityadmin.sh emits this error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
