### PR TITLE
[Backport 1.x] Wait for port to be open instead of hard-coded 10 seconds

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -190,9 +190,10 @@
     state: restarted
     enabled: yes
 
-- name: Pause for 10 seconds to provide sometime for OpenSearch start
-  pause:
-    seconds: 10
+- name: Wait for opensearch to startup
+  ansible.builtin.wait_for: host={{ hostvars[inventory_hostname]['ip'] }} port={{os_api_port}} delay=5 connect_timeout=1 timeout=120
+
+
 
 - name: Security Plugin configuration | Copy the opensearch security internal users template
   template:


### PR DESCRIPTION
### Description
[Backport 1.x] Wait for port to be open instead of hard-coded 10 seconds

### Issues Resolved
https://github.com/opensearch-project/ansible-playbook/pull/123

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
