### PR TITLE
Copy custom security config when: auth_type == 'oidc' or copy_custom_security_configs

### DIFF
--- a/roles/linux/opensearch/tasks/security.yml
+++ b/roles/linux/opensearch/tasks/security.yml
@@ -164,7 +164,7 @@
     group: "{{ os_user }}"
     mode: 0600
     force: true
-  when: auth_type == 'oidc'
+  when: auth_type == 'oidc' or copy_custom_security_configs
 
 - name: Security Plugin configuration | Prepare the opensearch security configuration file
   ansible.builtin.command: sed -i 's/searchguard/plugins.security/g' {{ os_conf_dir }}/opensearch.yml


### PR DESCRIPTION
### Description
Fix implementation as suggested in issue:
Copy security config when: auth_type == 'oidc' or copy_custom_security_configs

### Issues Resolved
#116

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
