### PR TITLE
Update 2.x ansible playbook to use 2.15.0 release

### DIFF
--- a/inventories/opensearch/group_vars/all/all.yml
+++ b/inventories/opensearch/group_vars/all/all.yml
@@ -7,11 +7,11 @@ os_download_url: https://artifacts.opensearch.org/releases/bundle/opensearch
 
 # opensearch version
 # 2.x Latest Version
-os_version: "2.14.0"
+os_version: "2.15.0"
 
 # opensearch dashboards version
 # 2.x Latest Version
-os_dashboards_version: "2.14.0"
+os_dashboards_version: "2.15.0"
 
 # Configure hostnames for opensearch nodes
 # It is required to configure SSL


### PR DESCRIPTION
### Description
Update 2.x ansible playbook to use 2.15.0 release

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
