### PR TITLE
feat: add ansible-galaxy metadata

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,83 @@
+---
+#SPDX-License-Identifier: MIT-0
+namespace: opensearch
+name: opensearch
+version: 2.15.0
+readme: README.md
+
+# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
+# @nicks:irc/im.site#channel'
+# This was automatically generated from git using:
+# $ git shortlog --summary --numbered --email | sed -E 's_^( +[0-9]+\t)_  - _'
+authors:
+  - Abhinav Gupta <guptabhi123@gmail.com>
+  - Amazon GitHub Automation <54958958+amazon-auto@users.noreply.github.com>
+  - Anton Patsev <10828883+patsevanton@users.noreply.github.com>
+  - Barani <70038446+bbarani@users.noreply.github.com>
+  - Charles Santos <thyarles@gmail.com>
+  - Daniel (dB.) Doubrovkine <dblock@amazon.com>
+  - Daniel (dB.) Doubrovkine <dblock@dblock.org>
+  - Darshit Chanpura <35282393+DarshitChanpura@users.noreply.github.com>
+  - Divya Madala <113469545+Divyaasm@users.noreply.github.com>
+  - Florian Heiderich <florian@heiderich.org>
+  - maxtimofeev <75588026+maxtimofeev@users.noreply.github.com>
+  - mend-for-github-com[bot] <50673670+mend-for-github-com[bot]@users.noreply.github.com>
+  - mpsOxygen <undercover_black_hat@yahoo.com>
+  - ng-bsy <111761573+ng-bsy@users.noreply.github.com>
+  - Peter Zhu <zhujiaxi@amazon.com>
+  - Prudhvi Godithi <pgodithi@amazon.com>
+  - Rishabh Singh <rishabhksingh@gmail.com>
+  - Rishabh Singh <sngri@amazon.com>
+  - Rodolfo Câmara Villordo <rodolfovillordo@gmail.com>
+  - Ryan Bogan <10944539+ryanbogan@users.noreply.github.com>
+  - Saravanan Palanisamy <saravanan30erd@gmail.com>
+  - Sayali Gaikawad <61760125+gaiksaya@users.noreply.github.com>
+  - ssi444 <55582328+ssi444@users.noreply.github.com>
+  - Zelin Hao <87548827+zelinh@users.noreply.github.com>
+  - Zelin Hao <zelinhao@amazon.com>
+
+description: Roles for deploying opensearch and related components
+license_file: 'LICENSE.txt'
+tags: [opensearch]
+
+# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
+# collection label 'namespace.name'. The value is a version range
+# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
+# range specifiers can be set and are separated by ','
+dependencies: {}
+
+# The URL of the originating SCM repository
+repository: https://github.com/opensearch-project/ansible-playbook
+
+# The URL to any online docs
+documentation: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/ansible
+
+# The URL to the homepage of the collection/project
+homepage: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/ansible
+
+# The URL to the collection issue tracker
+issues: http://example.com/issue/tracker
+
+# A list of file glob-like patterns used to filter any files or directories that should not be included in the build
+# artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
+# uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
+# and '.git' are always filtered. Mutually exclusive with 'manifest'
+
+build_ignore:
+  - .github
+  - .gitignore
+  - changelogs
+  - roles/*/molecule
+  - inventories
+  - files
+  - .*
+  - '*test-requirements.txt'
+  - '*.tar.gz'
+  - opensearch.yml
+
+# A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
+# list of MANIFEST.in style
+# L(directives,https://packaging.python.org/en/latest/guides/using-manifest-in/#manifest-in-commands). The key
+# 'omit_default_directives' is a boolean that controls whether the default directives are used. Mutually exclusive
+# with 'build_ignore'
+# manifest: null


### PR DESCRIPTION
### Description

Related to https://github.com/opensearch-project/ansible-playbook/issues/44

This is a first step for publishing to Ansible galaxy.

It also enabled users to install the collection into their existing ansible projects directly from git.

This can be tested already, using a requirements file like this:
```
---
collections:
  - name: opensearch.opensearch
    type: git
    source: git+https://github.com/4censord/opensearch-ansible-playbook
```
or respective `ansible-galaxy collection install git+https://github.com/4censord/opensearch-ansible-playbook`

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
