### PR TITLE
Update job name dashboards.yml

### DIFF
--- a/roles/linux/dashboards/tasks/dashboards.yml
+++ b/roles/linux/dashboards/tasks/dashboards.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Dashboards Install | Download opensearch dashbaord {{ os_dashboards_version }}
+- name: Dashboards Install | Download opensearch dashboard {{ os_dashboards_version }}
   ansible.builtin.get_url:
     url: "{{ os_download_url }}-dashboards/{{ os_dashboards_version }}/opensearch-dashboards-{{ os_dashboards_version }}-linux-x64.tar.gz"
     dest: "/tmp/opensearch-dashboards.tar.gz"


### PR DESCRIPTION
Summary:

Updated the job name in the Ansible playbook for better clarity and consistency.

Why:

The previous job name was either generic or outdated.

This change improves readability and helps identify the purpose of the task more easily during playbook execution or in logs.

Impact:

No functional changes to the playbook itself.

Should not affect existing deployments.