### PR TITLE
Removing ansible.builtin.command: systemctl daemon-reload from handler

### DIFF
--- a/roles/linux/opensearch/handlers/main.yml
+++ b/roles/linux/opensearch/handlers/main.yml
@@ -1,10 +1,8 @@
 ---
-# handlers file for opensearch
-- name: reload systemd configuration
-  become: true
-  ansible.builtin.command: systemctl daemon-reload
-
-# Restart service and ensure it is enabled
 
 - name: restart opensearch
-  ansible.builtin.systemd: name=opensearch state=restarted enabled=yes
+  ansible.builtin.service:
+    name: opensearch
+    state: restarted
+    enabled: yes
+    daemon_reload: yes


### PR DESCRIPTION
### Description
Ansible resource service and systemd already provides a daemon_reload parameter to reload systemd

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
